### PR TITLE
feat: Add `ShareType` enum to replace `Type` with more JS native naming

### DIFF
--- a/lib/index.spec.ts
+++ b/lib/index.spec.ts
@@ -3,17 +3,17 @@
  * SPDX-License-Identifier: CC0-1.0
  */
 import { expect, test } from 'vitest'
-import { Type } from '.'
+import { ShareType } from '.'
 
 test('ShareType', () => {
-	for (const type of Object.values(Type)) {
+	for (const type of Object.values(ShareType)) {
 		if (typeof type === 'string') {
 			// This should be the key of the enum, so we should be able to get the value
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			expect((Type as any)[type]).toBeTypeOf('number')
+			expect((ShareType as any)[type]).toBeTypeOf('number')
 		} else {
 			expect(type).toBeTypeOf('number')
-			expect(Type[type]).toBeTypeOf('string')
+			expect(ShareType[type]).toBeTypeOf('string')
 		}
 	}
 })

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,3 +1,9 @@
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+/** @deprecated will be removed with the next version use `ShareType` instead */
 export enum Type {
 	SHARE_TYPE_USER = 0,
 	SHARE_TYPE_GROUP = 1,
@@ -13,4 +19,24 @@ export enum Type {
 	 * @since 26.0.0
 	 */
 	SHARE_TYPE_FEDERATED_GROUP = 14,
+}
+
+export enum ShareType {
+	User = 0,
+	Grup = 1,
+	Link = 3,
+	Email = 4,
+	Remote = 6,
+	/**
+	 * Was called `Circle` before Nextcloud 29
+	 */
+	Team = 7,
+	Guest = 8,
+	RemoteGroup = 9,
+	Room = 10,
+	Deck = 12,
+	/**
+	 * @since 26.0.0
+	 */
+	FederatedGroup = 14,
 }


### PR DESCRIPTION
* [x] :warning: This is based on (needs to merge that one first) #21 

This also prevents name clashes with other `Type` classes or enums