### PR TITLE
chore: Prepare 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,35 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
-## 2.0.0 – 2021-04-07
+## 0.2.0 - 2024-06-19
+
+### Added
+
+-   Add federated_group share type \([\#13](https://github.com/nextcloud-libraries/nextcloud-sharing/pull/13)\)
+-   feat: Add `ShareType` enum to replace `Type` with more JS native naming \([\#22](https://github.com/nextcloud-libraries/nextcloud-sharing/pull/22)\)
+-   feat: Add utils for public link shares \([\#24](https://github.com/nextcloud-libraries/nextcloud-sharing/pull/24)\)
 
 ### Changed
 
--   Browserslist config updates, which means some older browsers are no longer supported
--   Dependency updates
+-   Refactor: Use Vite, Vitest add ESLint and Prettier \([\#21](https://github.com/nextcloud-libraries/nextcloud-sharing/pull/21)\)
+-   chore: update node engines to next LTS (v20)
+-   chore: Add CI to block unconventional commits
+-   chore: Update workflows from organization
 
-## 1.1.2 - 2020-04-06
+## 0.1.0 - 2021-08-18
 
-### Changed
+### Added
 
--   Dependency updates
-
-### Fixed
-
--   Update vulnerable packages
-
-## 1.1.1 - 2020-03-19
-
-### Changed
-
--   Dependency updates
-
-### Fixed
-
--   Update vulnerable packages
-
-## 1.1.0 - 2020-01-08
-
-### Changed
-
--   Updated documentation
+-   Initial implementation

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/sharing",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/sharing",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/initial-state": "^2.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/sharing",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Front-end utilities for Nextcloud files sharing",
   "keywords": [
     "nextcloud"


### PR DESCRIPTION
## 0.2.0 - 2024-06-19

### Added

-   Add federated_group share type \([\#13](https://github.com/nextcloud-libraries/nextcloud-sharing/pull/13)\)
-   feat: Add `ShareType` enum to replace `Type` with more JS native naming \([\#22](https://github.com/nextcloud-libraries/nextcloud-sharing/pull/22)\)
-   feat: Add utils for public link shares \([\#24](https://github.com/nextcloud-libraries/nextcloud-sharing/pull/24)\)

### Changed

-   Refactor: Use Vite, Vitest add ESLint and Prettier \([\#21](https://github.com/nextcloud-libraries/nextcloud-sharing/pull/21)\)
-   chore: update node engines to next LTS (v20)
-   chore: Add CI to block unconventional commits
-   chore: Update workflows from organization