### PR TITLE
chore: Fix docs to correctly name `public` module

### DIFF
--- a/lib/publicShare.ts
+++ b/lib/publicShare.ts
@@ -1,6 +1,8 @@
 /**
  * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * @module public
  */
 import { loadState } from '@nextcloud/initial-state'
 


### PR DESCRIPTION
The file is called `publicShare` but we call the entry point `public` so we should align the docs.