### PR TITLE
chore: Prepare 0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.2.3 - 2024-07-24
+
+### Fixed
+
+-   fix: Typo in `ShareType.Group`
+
+### Changed
+
+-   Add SPDX license information header
+
 ## 0.2.2 - 2024-06-20
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/sharing",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/sharing",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/initial-state": "^2.2.0"

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/sharing",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Front-end utilities for Nextcloud files sharing",
   "keywords": [
     "nextcloud"
   ],
   "license": "GPL-3.0-or-later",
-  "author": "Christoph Wurst",
+  "author": "Nextcloud GmbH and Nextcloud contributors",
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
## 0.2.3 - 2024-07-24

### Fixed

-   fix: Typo in `ShareType.Group`

### Changed

-   Add SPDX license information header