### PR TITLE
chore: adjust node versions to support multiple Nextcloud versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,8 +28,7 @@
         "vitest": "^3.1.4"
       },
       "engines": {
-        "node": "^20.0.0",
-        "npm": "^10.0.0"
+        "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -5754,6 +5753,13 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/happy-dom/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/has-bigints": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,16 @@
     "vitest": "^3.1.4"
   },
   "engines": {
-    "node": "^20.0.0",
-    "npm": "^10.0.0"
+    "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
+  },
+  "devEngines": {
+    "packageManager": {
+      "name": "npm",
+      "version": "^10.0.0"
+    },
+    "runtime": {
+      "name": "node",
+      "version": "^22.0.0"
+    }
   }
 }


### PR DESCRIPTION
This is a library and should support multiple Nextcloud versions. E.g. Nextcloud 30 apps are bound to Node 20, current apps Node 22 and apps in a couple of month Node 24.
Thus - and because this is not a node but browser library - we should support all LTS Node versions in this range.

Instead we should just require specific development versions.