### PR TITLE
chore: prepare v0.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.2.5 - 2025-06-19
+### Changed
+* chore: adjust node versions to support multiple Nextcloud versions \([\#74](https://github.com/nextcloud-libraries/nextcloud-sharing/pull/74)\)
+* chore: move from `dev:watch` back to `watch` \([\#47](https://github.com/nextcloud-libraries/nextcloud-sharing/pull/47)\)
+* chore: update ESLint to v9 \([\#78](https://github.com/nextcloud-libraries/nextcloud-sharing/pull/78)\)
+* chore: update workflows from organization \([\#75](https://github.com/nextcloud-libraries/nextcloud-sharing/pull/75)\)
+* ci: add workflow to check for typescript issues \([\#79](https://github.com/nextcloud-libraries/nextcloud-sharing/pull/79)\)
+
 ## 0.2.4 - 2024-12-03
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/sharing",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/sharing",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/initial-state": "^2.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/sharing",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Front-end utilities for Nextcloud files sharing",
   "keywords": [
     "nextcloud"


### PR DESCRIPTION
Mostly to get rid of Node version warnings when installing this library.

---

## 0.2.5 - 2025-06-19
### Changed
* chore: adjust node versions to support multiple Nextcloud versions \([\#74](https://github.com/nextcloud-libraries/nextcloud-sharing/pull/74)\)
* chore: move from `dev:watch` back to `watch` \([\#47](https://github.com/nextcloud-libraries/nextcloud-sharing/pull/47)\)
* chore: update ESLint to v9 \([\#78](https://github.com/nextcloud-libraries/nextcloud-sharing/pull/78)\)
* chore: update workflows from organization \([\#75](https://github.com/nextcloud-libraries/nextcloud-sharing/pull/75)\)
* ci: add workflow to check for typescript issues \([\#79](https://github.com/nextcloud-libraries/nextcloud-sharing/pull/79)\)

