### PR TITLE
chore: prepare v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.3.0 - 2025-09-05
+### Breaking changes
+* The deprecated `Type` enum was removed. Instead use the `ShareType` enum provided from the main entry point.
+
+### Added
+* feat: provide API to register sidebar sections and actions \([\#95](https://github.com/nextcloud-libraries/nextcloud-sharing/pull/95)\)
+
+### Changed
+* ci: update npm-publish.yml workflow from template \([\#84](https://github.com/nextcloud-libraries/nextcloud-sharing/pull/84)\)
+* build: use vanilla Typescript for bundling \([\#74](https://github.com/nextcloud-libraries/nextcloud-sharing/pull/88)\)
+* chore(deps): Bump @nextcloud/initial-state to 3.0.0
+
 ## 0.2.5 - 2025-06-19
 ### Changed
 * chore: adjust node versions to support multiple Nextcloud versions \([\#74](https://github.com/nextcloud-libraries/nextcloud-sharing/pull/74)\)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/sharing",
-  "version": "0.2.5",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/sharing",
-      "version": "0.2.5",
+      "version": "0.3.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/initial-state": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/sharing",
-  "version": "0.2.5",
+  "version": "0.3.0",
   "description": "Front-end utilities for Nextcloud files sharing",
   "keywords": [
     "nextcloud"


### PR DESCRIPTION
## 0.3.0 - 2025-09-05
### Breaking changes
* The deprecated `Type` enum was removed. Instead use the `ShareType` enum provided from the main entry point.

### Added
* feat: provide API to register sidebar sections and actions \([\#95](https://github.com/nextcloud-libraries/nextcloud-sharing/pull/95)\)

### Changed
* ci: update npm-publish.yml workflow from template \([\#84](https://github.com/nextcloud-libraries/nextcloud-sharing/pull/84)\)
* build: use vanilla Typescript for bundling \([\#74](https://github.com/nextcloud-libraries/nextcloud-sharing/pull/88)\)
* chore(deps): Bump @nextcloud/initial-state to 3.0.0